### PR TITLE
Fixed scoreboard suffix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compileOnly 'io.github.miniplaceholders:miniplaceholders-api:2.2.3'
     paperweight.foliaDevBundle("1.20.4-R0.1-SNAPSHOT")
 
-    implementation("com.github.megavexnetwork.scoreboard-library:scoreboard-library-api:2.1.1")
+    implementation("com.github.megavexnetwork.scoreboard-library:scoreboard-library-api:2.0.2")
     runtimeOnly("com.github.megavexnetwork.scoreboard-library:scoreboard-library-implementation:2.0.2")
     runtimeOnly("com.github.megavexnetwork.scoreboard-library:scoreboard-library-modern:2.0.2")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     paperweight.foliaDevBundle("1.20.4-R0.1-SNAPSHOT")
 
     implementation("com.github.megavexnetwork.scoreboard-library:scoreboard-library-api:2.1.1")
-    runtimeOnly("com.github.megavexnetwork.scoreboard-library:scoreboard-library-implementation:2.1.1")
+    runtimeOnly("com.github.megavexnetwork.scoreboard-library:scoreboard-library-implementation:2.0.2")
     runtimeOnly("com.github.megavexnetwork.scoreboard-library:scoreboard-library-modern:2.1.1")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
     implementation("com.github.megavexnetwork.scoreboard-library:scoreboard-library-api:2.1.1")
     runtimeOnly("com.github.megavexnetwork.scoreboard-library:scoreboard-library-implementation:2.0.2")
-    runtimeOnly("com.github.megavexnetwork.scoreboard-library:scoreboard-library-modern:2.1.1")
+    runtimeOnly("com.github.megavexnetwork.scoreboard-library:scoreboard-library-modern:2.0.2")
 }
 
 shadowJar {


### PR DESCRIPTION
Apparently there is a bug with [scoreboard-library](https://github.com/MegavexNetwork/scoreboard-library) from version **2.1.0** for which the _prefix_ will be displayed as both the _prefix_ and the _suffix_ in scoreboard.
You can verify this in [TablistRankHeader](https://github.com/SimplyVanilla/SimplyTAB/blob/main/src/main/java/net/simplyvanilla/simplytab/rank/TablistRankHandler.java) at line `68`:
```java
display.suffix(MiniMessage.miniMessage().deserialize(
    this.plugin.getConfig().getString("group-suffix", ""),
    MiniPlaceholders.getAudienceGlobalPlaceholders(player)
));

System.out.println(this.plugin.getConfig().getString("group-suffix", "")); // Returns the correct value
System.out.println(display.suffix()); // Returns the value previously set in display.prefix()
```